### PR TITLE
Forcefully shutdown RPC to prevent hangs

### DIFF
--- a/redbot/core/_rpc.py
+++ b/redbot/core/_rpc.py
@@ -93,7 +93,14 @@ class RPC:
             self._started, _discard, self._site = (
                 True,
                 await self._runner.setup(),
-                web.TCPSite(self._runner, host="127.0.0.1", port=port, shutdown_timeout=0),
+                web.TCPSite(
+                    self._runner,
+                    host="127.0.0.1",
+                    port=port,
+                    shutdown_timeout=120
+                    # Give the RPC server 2 minutes to finish up, else slap it!
+                    # Seems like a reasonable time. See Red#6391
+                ),
             )
         except Exception as exc:
             log.exception("RPC setup failure", exc_info=exc)


### PR DESCRIPTION
### Description of the changes



### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes

<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->

should work 
pulling from upstream pr

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request enhances the RPC server shutdown process by increasing the shutdown timeout to 120 seconds, aiming to prevent potential hangs during the shutdown phase.

- **Enhancements**:
    - Increased the shutdown timeout for the RPC server to 120 seconds to prevent hangs during shutdown.

<!-- Generated by sourcery-ai[bot]: end summary -->