### PR TITLE
Get viewer count from stream data instead of user profile data (#6413)

### DIFF
--- a/redbot/cogs/streams/streamtypes.py
+++ b/redbot/cogs/streams/streamtypes.py
@@ -393,7 +393,6 @@ class TwitchStream(Stream):
             if user_profile_data is not None:
                 final_data["login"] = user_profile_data["login"]
                 final_data["profile_image_url"] = user_profile_data["profile_image_url"]
-                final_data["view_count"] = user_profile_data["view_count"]
 
             stream_data = stream_data["data"][0]
             final_data["user_name"] = self.display_name = stream_data["user_name"]
@@ -401,6 +400,7 @@ class TwitchStream(Stream):
             final_data["thumbnail_url"] = stream_data["thumbnail_url"]
             final_data["title"] = stream_data["title"]
             final_data["type"] = stream_data["type"]
+            final_data["view_count"] = stream_data["viewer_count"]
 
             __, follows_data = await self.get_data(
                 TWITCH_FOLLOWS_ENDPOINT, {"broadcaster_id": self.id}


### PR DESCRIPTION
### Description of the changes



### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes

<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request modifies the source of the viewer count in the stream types module, switching from user profile data to stream data for more accurate and relevant information.

- **Enhancements**:
    - Updated the viewer count source to use stream data instead of user profile data in the stream types module.

<!-- Generated by sourcery-ai[bot]: end summary -->