### PR TITLE
Bump lavalink 3712 172

### DIFF
--- a/redbot/cogs/audio/manager.py
+++ b/redbot/cogs/audio/manager.py
@@ -298,8 +298,8 @@ class LavalinkVersion:
 
 
 class ServerManager:
-    JAR_VERSION: Final[str] = LavalinkVersion(3, 7, 11, red=3)
-    YT_PLUGIN_VERSION: Final[str] = "1.5.2"
+    JAR_VERSION: Final[str] = LavalinkVersion(3, 7, 12, red=1)
+    YT_PLUGIN_VERSION: Final[str] = "1.7.2"
 
     LAVALINK_DOWNLOAD_URL: Final[str] = (
         "https://github.com/Cog-Creators/Lavalink-Jars/releases/download/"

--- a/redbot/cogs/trivia/data/lists/entertainment.yaml
+++ b/redbot/cogs/trivia/data/lists/entertainment.yaml
@@ -129,7 +129,7 @@ Hanna-Barbera rose to fame by creating what duo for MGM?:
 He directed "The Godfather"?:
 - Francis Ford Coppola
 He directed the movie E.T.?:
-- Stephen Spielberg
+- Steven Spielberg
 He starred in, "City Lights"?:
 - Charlie Chaplin
 He was known as the "Elephant Man"?:
@@ -427,7 +427,7 @@ The Who had a guinness world record for what?:
 The Who's rock musical stars Elton John. It's called ________?:
 - Tommy
 The director of Jaws, Raiders of the Lost Ark?:
-- Stephen spielberg
+- Steven Spielberg
 The eldest sister in the TV Series Charmed, is played by who?:
 - Shannon Doherty
 The film "Crouching Tiger, Hidden Dragon" takes place in which dynasty?:


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the Lavalink and YouTube plugin versions in the audio manager and fix the spelling of 'Steven Spielberg' in the trivia data list.

Bug Fixes:
- Correct the spelling of 'Steven Spielberg' in the trivia data list.

Enhancements:
- Update the Lavalink JAR version to 3.7.12 and the YouTube plugin version to 1.7.2 in the audio manager.

<!-- Generated by sourcery-ai[bot]: end summary -->